### PR TITLE
25 allow do not tweet words

### DIFF
--- a/Toot2Toulouse.Backend/Configuration/UserConfiguration.cs
+++ b/Toot2Toulouse.Backend/Configuration/UserConfiguration.cs
@@ -23,6 +23,7 @@ namespace Toot2Toulouse.Backend.Configuration
         public UserConfigurationFollowers Followers { get; set; } // followersearch settings (translate mastodon mentions to twitter mentions)
 
         public UserConfigurationAppSuffix AppSuffix { get; set; } // suffix to show on tweets
+        public List<string> DontTweet { get; set; } = new List<string>() { { "🐘"  } };
         public TimeSpan Delay { get; set; }
     
 

--- a/Toot2Toulouse.Backend/Twitter.cs
+++ b/Toot2Toulouse.Backend/Twitter.cs
@@ -46,6 +46,7 @@ namespace Toot2Toulouse.Backend
         {
             if (string.IsNullOrWhiteSpace(toot.Content)) return false;
             if (!user.Config.VisibilitiesToPost.Contains(toot.Visibility.ToT2t())) return false;
+            if (user.Config.DontTweet.Any(q=>toot.Content.Contains(q))) return false;   
             return true;
         }
 

--- a/Toot2Toulouse/config.example.json
+++ b/Toot2Toulouse/config.example.json
@@ -79,6 +79,7 @@
       "Prefix": "...",
       "Suffix": "..."
     },
+    "DontTweet": ["🐘"],
     "Replacements": {
       "Toot": "Tweet",
       "Boost": "Retweet",


### PR DESCRIPTION
Userconfig now contains a "donttweet"-property that allows to provide a list of words that should not be tweeted. This is not editable by the user yet